### PR TITLE
Match track px and py during MET computation

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -85,7 +85,7 @@ public:
 
   // Binning constants
   static constexpr double minRinv = -0.006;
-  static constexpr double minPhi0 = -0.69813248;  // relative to the center of the sector
+  static constexpr double minPhi0 = -0.7853981696;  // relative to the center of the sector
   static constexpr double minTanl = -8.;
   static constexpr double minZ0 = -20.46912512;
   static constexpr double minD0 = -16.;

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -80,9 +80,14 @@ process.L1TrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("Ver
 process.L1TrackJetsEmulation.VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
 process.L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
 process.L1TrackerEmuEtMiss.debug = options.debug
+process.L1TrackerEmuHTMiss.debug = (options.debug > 0)
 
 if options.debug:
     process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)
+    process.MessageLogger.suppressInfo = cms.untracked.vstring('CondDBESSource', 'PoolDBESSource')
+    process.MessageLogger.cerr.CondDBESSource = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    )
 
 process.GTTFileWriter.format = cms.untracked.string(options.format)
 # process.GTTFileWriter.outputFilename = cms.untracked.string("myOutputFile.txt")

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -22,14 +22,17 @@ namespace l1tmetemu {
   const unsigned int kPtMagSize{9};
   const unsigned int kEtExtra{4};
   const unsigned int kGlobalPhiExtra{3};
+  const unsigned int kCosLUTSize{10};
+  const unsigned int kCosLUTMagSize{1};
 
   typedef ap_uint<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kGlobalPhiExtra> global_phi_t;
-  typedef ap_fixed<kInternalPtWidth + kEtExtra + kEtExtra,kPtMagSize + kEtExtra> Et_t;
-  typedef ap_fixed<kInternalPtWidth + kPtMagSize + kEtExtra,2*kPtMagSize + kEtExtra> E2t_t;
+  typedef ap_ufixed<kCosLUTSize, kCosLUTMagSize, AP_RND_CONV, AP_SAT> cos_lut_fixed_t;
+  typedef ap_fixed<kInternalPtWidth + kEtExtra + kEtExtra, kPtMagSize + kEtExtra, AP_RND_CONV, AP_SAT> Et_t;
+  typedef ap_fixed<kInternalPtWidth + kPtMagSize + kEtExtra,2*kPtMagSize + kEtExtra, AP_RND_CONV, AP_SAT> E2t_t;
 
   // Output definition as per interface document, only used when creating output format
-  const float kMaxMET{2048};  // 2 TeV
-  const float kMaxMETPhi{2 * M_PI};
+  const double kMaxMET{2048};  // 2 TeV
+  const double kMaxMETPhi{2 * M_PI};
 
   const unsigned int kMETSize{16};     // For output Magnitude default 16
   const unsigned int kMETMagSize{11};
@@ -43,7 +46,7 @@ namespace l1tmetemu {
 
   // Enough symmetry in cos and sin between 0 and pi/2 to get all possible values
   // of cos and sin phi
-  const float kMaxCosLUTPhi{M_PI / 2};
+  const double kMaxCosLUTPhi{M_PI / 2};
 
   const unsigned int kNSector{9};
   const unsigned int kNQuadrants{4};
@@ -54,11 +57,20 @@ namespace l1tmetemu {
     METWordphi_t Phi;
   };
 
-  std::vector<Et_t> generateCosLUT(unsigned int size);
+  std::vector<cos_lut_fixed_t> generateCosLUT(unsigned int size);
 
   global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift );
   
   std::vector<global_phi_t> generatePhiSliceLUT(unsigned int N);
+
+  template <typename T>
+  void printLUT(std::vector<T> lut, std::string module = "", std::string name = "") {
+    edm::LogVerbatim log(module);
+    log << "The " << name << "[" << lut.size() << "] values are ... \n";
+    for (unsigned int i = 0; i < lut.size(); i++) {
+      log << "\t" << i << "\t" << lut[i] << "\n";
+    }
+  }
 
 }  // namespace l1tmetemu
 #endif

--- a/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissEmulatorProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TrackerEtMissEmulatorProducer_cfi.py
@@ -12,7 +12,7 @@ L1TrackerEmuEtMiss = cms.EDProducer('L1TrackerEtMissEmulatorProducer',
     # set useVertexEmulator to true
     L1MetCollectionName = cms.string("L1TrackerEmuEtMiss"),
     
-    nCordicSteps = cms.int32( 27 ), #Number of steps for cordic sqrt and phi computation
+    nCordicSteps = cms.int32( 13 ), #Number of steps for cordic sqrt and phi computation
     debug        = cms.int32( 6 ),  #0 - No Debug, 1 - LUT debug, 2 - Phi Debug, 3 - Z debug, 4 - Et Debug, 5 - Cordic Debug, 6 - Output, 7 - Every Selected Track
 
 )

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -3,15 +3,15 @@
 using namespace std;
 
 namespace l1tmetemu {
-  std::vector<Et_t> generateCosLUT(unsigned int size) {  // Fill cosine LUT with integer values
+  std::vector<cos_lut_fixed_t> generateCosLUT(unsigned int size) {  // Fill cosine LUT with integer values
     float phi = 0;
-    std::vector<Et_t> cosLUT;
+    std::vector<cos_lut_fixed_t> cosLUT;
     for (unsigned int LUT_idx = 0; LUT_idx < size; LUT_idx++) {
-      cosLUT.push_back((Et_t)(cos(phi)));
+      cosLUT.push_back((cos_lut_fixed_t)(cos(phi)));
       phi += TTTrack_TrackWord::stepPhi0;
-      //std::cout << LUT_idx << "," << (Et_t)(cos(phi)) << std::endl;
+      //std::cout << LUT_idx << "," << (cos_lut_fixed_t)(cos(phi)) << std::endl;
     }
-    cosLUT.push_back((Et_t)(0));  //Prevent overflow in last bin
+    cosLUT.push_back((cos_lut_fixed_t)(0));  //Prevent overflow in last bin
     return cosLUT;
   }
 


### PR DESCRIPTION
Changes which make the sum px and sum py match the firmware. There are still some differences in the final MET and MET phi values. These are some suggestions while the CORDIC function is being modified by @Chriisbrown.