### PR TITLE
Match emulation and firmware

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/Cordic.h
+++ b/L1Trigger/L1TTrackMatch/interface/Cordic.h
@@ -17,6 +17,8 @@ public:
   Cordic();
   Cordic(const int aSteps, bool debug);
 
+  template <typename T>
+  void cordic_subfunc(T &x, T &y, T &z) const;
   l1tmetemu::EtMiss toPolar(l1tmetemu::Et_t x, l1tmetemu::Et_t y) const;
 
 private:
@@ -25,9 +27,9 @@ private:
   const bool debug;
 
   // To calculate atan
-  std::vector<l1tmetemu::E2t_t> atanLUT;
+  std::vector<l1tmetemu::atan_lut_fixed_t> atanLUT;
   // To normalise final magnitude
-  std::vector<l1tmetemu::E2t_t> magNormalisationLUT;
+  std::vector<l1tmetemu::atan_lut_fixed_t> magNormalisationLUT;
 };
 
 #endif

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -18,10 +18,10 @@
 // Namespace that defines constants and types used by the EtMiss Emulation
 // Includes functions for writing LUTs and converting to integer representations
 namespace l1tmetemu {
-  
+
   const unsigned int kInternalPtWidth{14};
   const unsigned int kPtMagSize{9};
-  const unsigned int kMETSize{16};     // For output Magnitude default 16
+  const unsigned int kMETSize{16};  // For output Magnitude default 16
   const unsigned int kMETMagSize{11};
   const unsigned int kMETPhiSize{13};  // For Output Phi default 13
   const unsigned int kEtExtra{4};
@@ -31,7 +31,7 @@ namespace l1tmetemu {
   const unsigned int kAtanLUTSize{64};
   const unsigned int kAtanLUTMagSize{2};
 
-  typedef ap_ufixed<kMETSize,kMETMagSize, AP_RND_CONV, AP_SAT> METWord_t;
+  typedef ap_ufixed<kMETSize, kMETMagSize, AP_RND_CONV, AP_SAT> METWord_t;
   typedef ap_int<kMETPhiSize> METWordphi_t;
   typedef ap_int<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kGlobalPhiExtra> global_phi_t;
   typedef ap_ufixed<kCosLUTSize, kCosLUTMagSize, AP_RND_CONV, AP_SAT> cos_lut_fixed_t;
@@ -44,8 +44,8 @@ namespace l1tmetemu {
   const double kMaxMET = 1 << kMETMagSize;  // 2 TeV
   const double kMaxMETPhi{2 * M_PI};
 
-  const double kStepMETwordEt =  kMaxMET / ( 1 << kMETSize);
-  const double kStepMETwordPhi = kMaxMETPhi / ( 1 << kMETPhiSize);
+  const double kStepMETwordEt = kMaxMET / (1 << kMETSize);
+  const double kStepMETwordPhi = kMaxMETPhi / (1 << kMETPhiSize);
   const double kBinsInPi = 1.0 / kStepMETwordPhi;
 
   // Enough symmetry in cos and sin between 0 and pi/2 to get all possible values
@@ -63,8 +63,8 @@ namespace l1tmetemu {
 
   std::vector<cos_lut_fixed_t> generateCosLUT(unsigned int size);
 
-  global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift );
-  
+  global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift);
+
   std::vector<global_phi_t> generatePhiSliceLUT(unsigned int N);
 
   template <typename T>

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -20,29 +20,32 @@ namespace l1tmetemu {
   
   const unsigned int kInternalPtWidth{14};
   const unsigned int kPtMagSize{9};
+  const unsigned int kMETSize{16};     // For output Magnitude default 16
+  const unsigned int kMETMagSize{11};
+  const unsigned int kMETPhiSize{13};  // For Output Phi default 13
   const unsigned int kEtExtra{4};
   const unsigned int kGlobalPhiExtra{3};
   const unsigned int kCosLUTSize{10};
   const unsigned int kCosLUTMagSize{1};
-
-  typedef ap_uint<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kGlobalPhiExtra> global_phi_t;
-  typedef ap_ufixed<kCosLUTSize, kCosLUTMagSize, AP_RND_CONV, AP_SAT> cos_lut_fixed_t;
-  typedef ap_fixed<kInternalPtWidth + kEtExtra + kEtExtra, kPtMagSize + kEtExtra, AP_RND_CONV, AP_SAT> Et_t;
-  typedef ap_fixed<kInternalPtWidth + kPtMagSize + kEtExtra,2*kPtMagSize + kEtExtra, AP_RND_CONV, AP_SAT> E2t_t;
-
-  // Output definition as per interface document, only used when creating output format
-  const double kMaxMET{2048};  // 2 TeV
-  const double kMaxMETPhi{2 * M_PI};
-
-  const unsigned int kMETSize{16};     // For output Magnitude default 16
-  const unsigned int kMETMagSize{11};
-  const unsigned int kMETPhiSize{13};  // For Output Phi default 13
+  const unsigned int kAtanLUTSize{64};
+  const unsigned int kAtanLUTMagSize{2};
 
   typedef ap_ufixed<kMETSize,kMETMagSize> METWord_t;
   typedef ap_int<kMETPhiSize> METWordphi_t;
+  typedef ap_uint<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kGlobalPhiExtra> global_phi_t;
+  typedef ap_ufixed<kCosLUTSize, kCosLUTMagSize, AP_RND_CONV, AP_SAT> cos_lut_fixed_t;
+  typedef ap_ufixed<kAtanLUTSize, kAtanLUTMagSize, AP_RND_CONV, AP_SAT> atan_lut_fixed_t;
+  typedef ap_fixed<kMETSize + kEtExtra, kMETMagSize + kEtExtra, AP_RND_CONV, AP_SAT> Et_t;
+  typedef ap_fixed<kMETPhiSize + kEtExtra, 4, AP_RND_CONV, AP_SAT> metphi_fixed_t;
+  typedef ap_ufixed<kMETPhiSize + kEtExtra + 7, kMETPhiSize - 2, AP_RND_CONV, AP_SAT> pi_bins_fixed_t;
+
+  // Output definition as per interface document, only used when creating output format
+  const double kMaxMET = 1 << kMETMagSize;  // 2 TeV
+  const double kMaxMETPhi{2 * M_PI};
 
   const double kStepMETwordEt =  kMaxMET / ( 1 << kMETSize);
   const double kStepMETwordPhi = kMaxMETPhi / ( 1 << kMETPhiSize);
+  const double kBinsInPi = 1.0 / kStepMETwordPhi;
 
   // Enough symmetry in cos and sin between 0 and pi/2 to get all possible values
   // of cos and sin phi

--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iomanip>
 #include <numeric>
 
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
@@ -24,15 +25,15 @@ namespace l1tmetemu {
   const unsigned int kMETMagSize{11};
   const unsigned int kMETPhiSize{13};  // For Output Phi default 13
   const unsigned int kEtExtra{4};
-  const unsigned int kGlobalPhiExtra{3};
+  const unsigned int kGlobalPhiExtra{4};
   const unsigned int kCosLUTSize{10};
   const unsigned int kCosLUTMagSize{1};
   const unsigned int kAtanLUTSize{64};
   const unsigned int kAtanLUTMagSize{2};
 
-  typedef ap_ufixed<kMETSize,kMETMagSize> METWord_t;
+  typedef ap_ufixed<kMETSize,kMETMagSize, AP_RND_CONV, AP_SAT> METWord_t;
   typedef ap_int<kMETPhiSize> METWordphi_t;
-  typedef ap_uint<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kGlobalPhiExtra> global_phi_t;
+  typedef ap_int<TTTrack_TrackWord::TrackBitWidths::kPhiSize + kGlobalPhiExtra> global_phi_t;
   typedef ap_ufixed<kCosLUTSize, kCosLUTMagSize, AP_RND_CONV, AP_SAT> cos_lut_fixed_t;
   typedef ap_ufixed<kAtanLUTSize, kAtanLUTMagSize, AP_RND_CONV, AP_SAT> atan_lut_fixed_t;
   typedef ap_fixed<kMETSize + kEtExtra, kMETMagSize + kEtExtra, AP_RND_CONV, AP_SAT> Et_t;
@@ -69,7 +70,7 @@ namespace l1tmetemu {
   template <typename T>
   void printLUT(std::vector<T> lut, std::string module = "", std::string name = "") {
     edm::LogVerbatim log(module);
-    log << "The " << name << "[" << lut.size() << "] values are ... \n";
+    log << "The " << name << "[" << lut.size() << "] values are ... \n" << std::setprecision(30);
     for (unsigned int i = 0; i < lut.size(); i++) {
       log << "\t" << i << "\t" << lut[i] << "\n";
     }

--- a/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
@@ -27,7 +27,7 @@ namespace l1tmhtemu {
   // extra room for sumPx, sumPy
   const unsigned int kEtExtra{10};
   const unsigned int kValidSize{1};
-  const unsigned int kMHTSize{16};     // For output Magnitude default 15
+  const unsigned int kMHTSize{16};  // For output Magnitude default 15
   const unsigned int kMHTIntSize{11};
   const unsigned int kMHTPhiSize{13};  // For output Phi default 14
   const unsigned int kHTSize{kInternalPtWidth + kEtExtra};
@@ -56,7 +56,7 @@ namespace l1tmhtemu {
   typedef ap_int<kInternalPhiWidth> phi_t;
 
   typedef ap_int<kHTSize> Et_t;
-  typedef ap_ufixed<kMHTSize,kMHTIntSize> MHT_t;
+  typedef ap_ufixed<kMHTSize, kMHTIntSize> MHT_t;
   typedef ap_uint<kMHTPhiSize> MHTphi_t;
 
   const unsigned int kMHTBins = 1 << kMHTSize;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkHTMissEmulatorProducer.cc
@@ -249,13 +249,12 @@ void L1TkHTMissEmulatorProducer::produce(edm::Event& iEvent, const edm::EventSet
         << "\n"
         << "====MHT AP_INTS TO FLOATS====\n"
         << "sumPx: " << (float)sumPx * l1tmhtemu::kStepPt * l1tmhtemu::kStepPhi
-        << "| sumPy: " << (float)sumPy * l1tmhtemu::kStepPt * l1tmhtemu::kStepPhi
-        << "| ET: " << EtMiss.Et.to_double() << "| HT: " << (float)HT * l1tmhtemu::kStepPt
-        << "| PHI: " << (float)phi * l1tmhtemu::kStepMHTPhi - M_PI << "\n"
+        << "| sumPy: " << (float)sumPy * l1tmhtemu::kStepPt * l1tmhtemu::kStepPhi << "| ET: " << EtMiss.Et.to_double()
+        << "| HT: " << (float)HT * l1tmhtemu::kStepPt << "| PHI: " << (float)phi * l1tmhtemu::kStepMHTPhi - M_PI << "\n"
         << "-------------------------------------------------------------------------\n";
   }
   //rescale HT to correct output range
-  HT = HT / (int)(1/l1tmhtemu::kStepPt);
+  HT = HT / (int)(1 / l1tmhtemu::kStepPt);
 
   EtSum L1HTSum(missingEt, EtSum::EtSumType::kMissingHt, (int)HT.range(), 0, (int)phi, (int)jetn);
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -76,7 +76,6 @@ L1TrackerEtMissEmulatorProducer::L1TrackerEtMissEmulatorProducer(const edm::Para
     : trackToken_(consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<edm::InputTag>("L1TrackInputTag"))),
       vtxAssocTrackToken_(
           consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<edm::InputTag>("L1TrackAssociatedInputTag"))) {
-
   phiQuadrants_ = l1tmetemu::generatePhiSliceLUT(l1tmetemu::kNQuadrants);
   phiShifts_ = l1tmetemu::generatePhiSliceLUT(l1tmetemu::kNSector);
 
@@ -148,7 +147,6 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
   for (const auto& track : *L1TTTrackHandle) {
     if (std::find(L1TTTrackAssociatedHandle->begin(), L1TTTrackAssociatedHandle->end(), track) !=
         L1TTTrackAssociatedHandle->end()) {
-
       bool EtaSector = (track->getTanlWord() & (1 << (TTTrack_TrackWord::TrackBitWidths::kTanlSize - 1)));
 
       ap_uint<TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1> ptEmulationBits = track->getTrackWord()(
@@ -156,16 +154,17 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
       ap_ufixed<TTTrack_TrackWord::TrackBitWidths::kRinvSize - 1, l1tmetemu::kPtMagSize> ptEmulation;
       ptEmulation.V = ptEmulationBits.range();
 
-      l1tmetemu::global_phi_t globalPhi = l1tmetemu::localToGlobalPhi(track->getPhiWord(),phiShifts_[track->phiSector()]);
+      l1tmetemu::global_phi_t globalPhi =
+          l1tmetemu::localToGlobalPhi(track->getPhiWord(), phiShifts_[track->phiSector()]);
 
       num_assoc_tracks++;
       if (debug_ == 7) {
         edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
             << "Track to Vertex ID: " << num_assoc_tracks << "\n"
-            << "Phi Sector: " << track->phiSector() << " pT: " << track->getRinvWord() << " Phi: " << track->getPhiWord()
-            << " TanL: " << track->getTanlWord() << " Z0: " << track->getZ0Word()
+            << "Phi Sector: " << track->phiSector() << " pT: " << track->getRinvWord()
+            << " Phi: " << track->getPhiWord() << " TanL: " << track->getTanlWord() << " Z0: " << track->getZ0Word()
             << " Chi2rphi: " << track->getChi2RPhiWord() << " Chi2rz: " << track->getChi2RZWord()
-            << " bendChi2: " << track->getBendChi2Word() << " Emu pT " << ptEmulation.to_double() <<  "\n"
+            << " bendChi2: " << track->getBendChi2Word() << " Emu pT " << ptEmulation.to_double() << "\n"
             << "--------------------------------------------------------------\n";
       }
 
@@ -173,11 +172,12 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
         edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
             << "========================Phi debug=================================\n"
             << "Emu pT: " << ptEmulation.to_double() << " float pT: " << track->momentum().perp() << "\n"
-            << "Int Phi: " << globalPhi << " Float Phi: " << track->phi()
-            << " Float Cos(Phi): " << cos(track->phi()) << "  Float Sin(Phi): " << sin(track->phi()) 
-            << " Float Px: " << track->momentum().perp()*cos(track->phi()) << " Float Py: "  << track->momentum().perp()*sin(track->phi()) << "\n";
+            << "Int Phi: " << globalPhi << " Float Phi: " << track->phi() << " Float Cos(Phi): " << cos(track->phi())
+            << "  Float Sin(Phi): " << sin(track->phi())
+            << " Float Px: " << track->momentum().perp() * cos(track->phi())
+            << " Float Py: " << track->momentum().perp() * sin(track->phi()) << "\n";
       }
-      
+
       l1tmetemu::Et_t temppx = 0;
       l1tmetemu::Et_t temppy = 0;
 
@@ -193,7 +193,6 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
               << "Sector: " << track->phiSector() << " Quadrant: " << 1 << "\n"
               << "Emu Phi: " << globalPhi << " Emu Cos(Phi): " << cosLUT_[globalPhi]
               << " Emu Sin(Phi): " << cosLUT_[phiQuadrants_[1] - 1 - globalPhi] << "\n";
-
         }
       } else if (globalPhi >= phiQuadrants_[1] && globalPhi < phiQuadrants_[2]) {
         temppx = -((l1tmetemu::Et_t)ptEmulation * cosLUT_[phiQuadrants_[2] - 1 - globalPhi]);
@@ -202,8 +201,7 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
         if (debug_ == 2) {
           edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
               << "Sector: " << track->phiSector() << " Quadrant: " << 2 << "\n"
-              << "Emu Phi: " << globalPhi << " Emu Cos(Phi): -"
-              << cosLUT_[phiQuadrants_[2] - 1 - globalPhi]
+              << "Emu Phi: " << globalPhi << " Emu Cos(Phi): -" << cosLUT_[phiQuadrants_[2] - 1 - globalPhi]
               << " Emu Sin(Phi): " << cosLUT_[globalPhi - phiQuadrants_[1]] << "\n";
         }
       } else if (globalPhi >= phiQuadrants_[2] && globalPhi < phiQuadrants_[3]) {
@@ -224,9 +222,8 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
         if (debug_ == 2) {
           edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
               << "Sector: " << track->phiSector() << " Quadrant: " << 4 << "\n"
-              << " Emu Phi: " << globalPhi
-              << " Emu Cos(Phi): " << cosLUT_[phiQuadrants_[4] - 1 - globalPhi] << " Emu Sin(Phi): -"
-              << cosLUT_[globalPhi - phiQuadrants_[3]] << "\n";
+              << " Emu Phi: " << globalPhi << " Emu Cos(Phi): " << cosLUT_[phiQuadrants_[4] - 1 - globalPhi]
+              << " Emu Sin(Phi): -" << cosLUT_[globalPhi - phiQuadrants_[3]] << "\n";
         }
       } else {
         temppx = 0;
@@ -240,11 +237,11 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
 
       if (debug_ == 4) {
         edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
-            << std::setprecision(8)
-            << "Sector: " << track->phiSector() << " Eta sector: " << EtaSector << "\n"
-            << "Track Ref Pt: " << track->momentum().perp()
-            << " Track Ref Px: " << track->momentum().x() << " Track Ref Py: " << track->momentum().y() << "\n"
-            << "Track Pt: " << ptEmulation << " Track phi: " << globalPhi << " Track Px: " << temppx << " Track Py: " << temppy << "\n"
+            << std::setprecision(8) << "Sector: " << track->phiSector() << " Eta sector: " << EtaSector << "\n"
+            << "Track Ref Pt: " << track->momentum().perp() << " Track Ref Px: " << track->momentum().x()
+            << " Track Ref Py: " << track->momentum().y() << "\n"
+            << "Track Pt: " << ptEmulation << " Track phi: " << globalPhi << " Track Px: " << temppx
+            << " Track Py: " << temppy << "\n"
             << "Sector Sum Px: " << sumPx[link_number] << " Sector Sum Py: " << sumPy[link_number] << "\n";
       }
     }
@@ -264,16 +261,13 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
   l1tmetemu::EtMiss EtMiss = cordicSqrt.toPolar(-GlobalPx, -GlobalPy);
 
   if (debug_ == 4 || debug_ == 6) {
-
-    edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
-        << "====Sector Pt====\n";
+    edm::LogVerbatim("L1TrackerEtMissEmulatorProducer") << "====Sector Pt====\n";
 
     for (unsigned int i = 0; i < l1tmetemu::kNSector * 2; i++) {
       edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
-        << "Sector " << i << "\n"
-        << "Px: " << sumPx[i]  << " | Py: " << sumPy[i]
-        << " | Link Totals: " << link_totals[i]
-        << " | Sector Totals: " << sector_totals[(int)(i/2)] << "\n";
+          << "Sector " << i << "\n"
+          << "Px: " << sumPx[i] << " | Py: " << sumPy[i] << " | Link Totals: " << link_totals[i]
+          << " | Sector Totals: " << sector_totals[(int)(i / 2)] << "\n";
     }
 
     edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
@@ -282,9 +276,9 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
 
     edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
         << "====MET===\n"
-        << "MET word Et: " << EtMiss.Et.range()*l1tmetemu::kStepMETwordEt << "| MET word phi: " << EtMiss.Phi << "\n"
-        << "MET: " << EtMiss.Et.to_double() 
-        << "| MET phi: " << EtMiss.Phi.to_double() * l1tmetemu::kStepMETwordPhi << "\n"
+        << "MET word Et: " << EtMiss.Et.range() * l1tmetemu::kStepMETwordEt << "| MET word phi: " << EtMiss.Phi << "\n"
+        << "MET: " << EtMiss.Et.to_double() << "| MET phi: " << EtMiss.Phi.to_double() * l1tmetemu::kStepMETwordPhi
+        << "\n"
         << "Word MET: " << EtMiss.Et.to_string(2) << " | Word MET phi: " << EtMiss.Phi.to_string(2) << "\n"
         << "# Tracks Associated to Vertex: " << num_assoc_tracks << "\n"
         << "========================================================\n";

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -136,8 +136,8 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
 
   // Initialize sector sums, need 0 initialization in case a sector has no
   // tracks
-  l1tmetemu::E2t_t sumPx[l1tmetemu::kNSector * 2] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  l1tmetemu::E2t_t sumPy[l1tmetemu::kNSector * 2] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  l1tmetemu::Et_t sumPx[l1tmetemu::kNSector * 2] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  l1tmetemu::Et_t sumPy[l1tmetemu::kNSector * 2] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   int link_totals[l1tmetemu::kNSector * 2] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   int sector_totals[l1tmetemu::kNSector] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
 
@@ -177,8 +177,8 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
             << " Float Px: " << track->momentum().perp()*cos(track->phi()) << " Float Py: "  << track->momentum().perp()*sin(track->phi()) << "\n";
       }
       
-      l1tmetemu::E2t_t temppx = 0;
-      l1tmetemu::E2t_t temppy = 0;
+      l1tmetemu::Et_t temppx = 0;
+      l1tmetemu::Et_t temppy = 0;
 
       // Split tracks in phi quadrants and access cosLUT_, backwards iteration
       // through cosLUT_ gives sin Sum sector Et -ve when cos or sin phi are -ve
@@ -248,8 +248,8 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
     }
   }  // end loop over tracks
 
-  l1tmetemu::E2t_t GlobalPx = 0;
-  l1tmetemu::E2t_t GlobalPy = 0;
+  l1tmetemu::Et_t GlobalPx = 0;
+  l1tmetemu::Et_t GlobalPy = 0;
 
   // Global Et sum as floats to emulate rounding in HW
   for (unsigned int i = 0; i < l1tmetemu::kNSector * 2; i++) {
@@ -259,12 +259,7 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
 
   // Perform cordic sqrt, take x,y and converts to polar coordinate r,phi where
   // r=sqrt(x**2+y**2) and phi = atan(y/x)
-  l1tmetemu::EtMiss EtMiss = cordicSqrt.toPolar(GlobalPx, GlobalPy);
-
-  if ((GlobalPx < 0) && (GlobalPy < 0))
-    EtMiss.Phi -=  l1tmetemu::METWordphi_t(M_PI/l1tmetemu::kStepMETwordPhi);
-  else if ((GlobalPx < 0) && (GlobalPy >= 0))
-    EtMiss.Phi += l1tmetemu::METWordphi_t(M_PI/l1tmetemu::kStepMETwordPhi);
+  l1tmetemu::EtMiss EtMiss = cordicSqrt.toPolar(-GlobalPx, -GlobalPy);
 
   if (debug_ == 4 || debug_ == 6) {
 
@@ -287,7 +282,7 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
         << "====MET===\n"
         << "MET word Et: " << EtMiss.Et.range()*l1tmetemu::kStepMETwordEt << "| MET word phi: " << EtMiss.Phi << "\n"
         << "MET: " << EtMiss.Et.to_double() 
-        << "| MET phi: " << (float)EtMiss.Phi * l1tmetemu::kStepMETwordPhi << "\n"
+        << "| MET phi: " << EtMiss.Phi.to_double() * l1tmetemu::kStepMETwordPhi << "\n"
         << "Word MET: " << EtMiss.Et.to_string(2) << " | Word MET phi: " << EtMiss.Phi.to_string(2) << "\n"
         << "# Tracks Associated to Vertex: " << num_assoc_tracks << "\n"
         << "========================================================\n";

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -17,6 +17,7 @@
 //
 
 // system include files
+#include <iomanip>
 #include <memory>
 #include <numeric>
 #include <sstream>
@@ -239,10 +240,11 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
 
       if (debug_ == 4) {
         edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
+            << std::setprecision(8)
             << "Sector: " << track->phiSector() << " Eta sector: " << EtaSector << "\n"
             << "Track Ref Pt: " << track->momentum().perp()
             << " Track Ref Px: " << track->momentum().x() << " Track Ref Py: " << track->momentum().y() << "\n"
-            << "Track Pt: " << ptEmulation << " Track Px: " << temppx << " Track Py: " << temppy << "\n"
+            << "Track Pt: " << ptEmulation << " Track phi: " << globalPhi << " Track Px: " << temppx << " Track Py: " << temppy << "\n"
             << "Sector Sum Px: " << sumPx[link_number] << " Sector Sum Py: " << sumPy[link_number] << "\n";
       }
     }

--- a/L1Trigger/L1TTrackMatch/src/Cordic.cc
+++ b/L1Trigger/L1TTrackMatch/src/Cordic.cc
@@ -6,9 +6,7 @@
 
 using namespace l1tmetemu;
 
-Cordic::Cordic(const int aSteps, bool debug)
-    : cordicSteps(aSteps),
-      debug(debug) {
+Cordic::Cordic(const int aSteps, bool debug) : cordicSteps(aSteps), debug(debug) {
   atanLUT.reserve(aSteps);
   magNormalisationLUT.reserve(aSteps);
 
@@ -40,8 +38,7 @@ template <typename T>
 void Cordic::cordic_subfunc(T &x, T &y, T &z) const {
   if (debug) {
     edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====Cordic Initial Conditions=====\n"
-                                           << "Cordic x: " << x << " Cordic y: " << y
-                                           << " Cordic z: " << z << "\n"
+                                           << "Cordic x: " << x << " Cordic y: " << y << " Cordic z: " << z << "\n"
                                            << "\n=====Cordic Steps=====";
   }
 
@@ -68,7 +65,6 @@ void Cordic::cordic_subfunc(T &x, T &y, T &z) const {
           << " Cordic gain: " << magNormalisationLUT[step] << " kStepMETwordPhi: " << kStepMETwordPhi << "\n";
     }
   }
-
 }
 
 EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
@@ -80,32 +76,29 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
   }
 
   // Some needed constants
-  const ap_fixed<l1tmetemu::Et_t::width + 1, 3> pi = M_PI;  // pi
-  const ap_fixed<l1tmetemu::Et_t::width + 2, 3> pi2 = M_PI / 2.;  // pi/2
-  const l1tmetemu::METWordphi_t pistep = M_PI / l1tmetemu::kStepMETwordPhi; // (pi) / l1tmetemu::kStepMETwordPhi
-  const l1tmetemu::METWordphi_t pi2step = pistep / 2.; // (pi/2) / l1tmetemu::kStepMETwordPhi
+  const ap_fixed<l1tmetemu::Et_t::width + 1, 3> pi = M_PI;                   // pi
+  const ap_fixed<l1tmetemu::Et_t::width + 2, 3> pi2 = M_PI / 2.;             // pi/2
+  const l1tmetemu::METWordphi_t pistep = M_PI / l1tmetemu::kStepMETwordPhi;  // (pi) / l1tmetemu::kStepMETwordPhi
+  const l1tmetemu::METWordphi_t pi2step = pistep / 2.;                       // (pi/2) / l1tmetemu::kStepMETwordPhi
 
   // Find the sign of the inputs
   ap_uint<2> signx = (x > 0) ? 2 : (x == 0) ? 1 : 0;
   ap_uint<2> signy = (y > 0) ? 2 : (y == 0) ? 1 : 0;
 
   // Corner cases
-  if (signy == 1 && signx == 2) { // y == 0 and x > 0
+  if (signy == 1 && signx == 2) {  // y == 0 and x > 0
     ret_etmiss.Et = x;
     ret_etmiss.Phi = 0;
     return ret_etmiss;
-  }
-  else if (signy == 1 && signx == 0) { // y == 0 and x < 0
+  } else if (signy == 1 && signx == 0) {  // y == 0 and x < 0
     ret_etmiss.Et = -x;
     ret_etmiss.Phi = pistep;
     return ret_etmiss;
-  }
-  else if (signy == 2 && signx == 1) { // y > 0 and x == 0
+  } else if (signy == 2 && signx == 1) {  // y > 0 and x == 0
     ret_etmiss.Et = y;
     ret_etmiss.Phi = pi2step;
     return ret_etmiss;
-  }
-  else if (signy == 0 && signx == 1) { // y < 0 and x == 0
+  } else if (signy == 0 && signx == 1) {  // y < 0 and x == 0
     ret_etmiss.Et = -y;
     ret_etmiss.Phi = -pi2step;
     return ret_etmiss;
@@ -115,15 +108,13 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
   ap_fixed<Et_t::width + 1, Et_t::iwidth + 1, Et_t::qmode, Et_t::omode> absx, absy;
   if (signy == 0) {
     absy = -y;
-  }
-  else {
+  } else {
     absy = y;
   }
 
   if (signx == 0) {
     absx = -x;
-  }
-  else {
+  } else {
     absx = x;
   }
 
@@ -140,8 +131,9 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
   }
 
   if (debug) {
-    edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====Normalized input=====\n"
-                                           << "norm(abs(x)): " << absx_sft.to_double() << " norm(abs(y)): " << absy_sft.to_double();
+    edm::LogVerbatim("L1TkEtMissEmulator")
+        << "\n=====Normalized input=====\n"
+        << "norm(abs(x)): " << absx_sft.to_double() << " norm(abs(y)): " << absy_sft.to_double();
   }
 
   // Setup the CORDIC inputs/outputs
@@ -150,16 +142,16 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
     cx = absy_sft;
     cy = absx_sft;
     cphi = 0;
-  }
-  else {
+  } else {
     cx = absx_sft;
     cy = absy_sft;
     cphi = 0;
   }
 
   if (debug) {
-    edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====CORDIC function arguments=====\n"
-                                           << "x: " << cx.to_double() << " y: " << cy.to_double() << " phi: " << cphi.to_double();
+    edm::LogVerbatim("L1TkEtMissEmulator")
+        << "\n=====CORDIC function arguments=====\n"
+        << "x: " << cx.to_double() << " y: " << cy.to_double() << " phi: " << cphi.to_double();
   }
 
   // Perform the CORDIC (vectoring) function
@@ -171,29 +163,28 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
   }
 
   ap_fixed<Et_t::width, 3, Et_t::qmode, Et_t::omode> ophi;
-  if (signx == 0 && signy == 2) { // x < 0 and y > 0
+  if (signx == 0 && signy == 2) {  // x < 0 and y > 0
     ophi = pi - cphi;
-  }
-  else if (signx == 0 && signy == 0) { // x < 0 and y < 0
+  } else if (signx == 0 && signy == 0) {  // x < 0 and y < 0
     ophi = cphi - pi;
-  }
-  else if (signx == 2 && signy == 0) { // x > 0 and y < 0
+  } else if (signx == 2 && signy == 0) {  // x > 0 and y < 0
     ophi = -cphi;
-  }
-  else {
+  } else {
     ophi = cphi;
   }
 
   // Re-scale the outputs
-  Et_t magnitude = ((ap_fixed<Et_t::width + Et_t::iwidth + 3 + 1, Et_t::iwidth, Et_t::qmode, Et_t::omode>)cx) << (Et_t::iwidth + 1 - 2);
+  Et_t magnitude = ((ap_fixed<Et_t::width + Et_t::iwidth + 3 + 1, Et_t::iwidth, Et_t::qmode, Et_t::omode>)cx)
+                   << (Et_t::iwidth + 1 - 2);
   ret_etmiss.Et = l1tmetemu::Et_t(magnitude * magNormalisationLUT[cordicSteps - 1]);
   ret_etmiss.Phi = ophi * pi_bins_fixed_t(kBinsInPi);
 
   if (debug) {
-    edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====toPolar output=====\n"
-                                           << std::setprecision(8)
-                                           << "magnitude: " << magnitude.to_double() << " phi: " << ophi.to_double() << " kBinsInPi: " << pi_bins_fixed_t(kBinsInPi).to_double() << "\n"
-                                           << "Et: " << ret_etmiss.Et.to_double() << " phi (int): " << ret_etmiss.Phi.to_int() << "\n";
+    edm::LogVerbatim("L1TkEtMissEmulator")
+        << "\n=====toPolar output=====\n"
+        << std::setprecision(8) << "magnitude: " << magnitude.to_double() << " phi: " << ophi.to_double()
+        << " kBinsInPi: " << pi_bins_fixed_t(kBinsInPi).to_double() << "\n"
+        << "Et: " << ret_etmiss.Et.to_double() << " phi (int): " << ret_etmiss.Phi.to_int() << "\n";
   }
 
   return ret_etmiss;

--- a/L1Trigger/L1TTrackMatch/src/Cordic.cc
+++ b/L1Trigger/L1TTrackMatch/src/Cordic.cc
@@ -1,6 +1,7 @@
 #include "L1Trigger/L1TTrackMatch/interface/Cordic.h"
 
 #include <cmath>
+#include <iomanip>
 #include <memory>
 
 using namespace l1tmetemu;
@@ -185,11 +186,12 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
 
   // Re-scale the outputs
   Et_t magnitude = ((ap_fixed<Et_t::width + Et_t::iwidth + 3 + 1, Et_t::iwidth, Et_t::qmode, Et_t::omode>)cx) << (Et_t::iwidth + 1 - 2);
-  ret_etmiss.Et = magnitude * magNormalisationLUT[cordicSteps - 1];
+  ret_etmiss.Et = l1tmetemu::Et_t(magnitude * magNormalisationLUT[cordicSteps - 1]);
   ret_etmiss.Phi = ophi * pi_bins_fixed_t(kBinsInPi);
 
   if (debug) {
     edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====toPolar output=====\n"
+                                           << std::setprecision(8)
                                            << "magnitude: " << magnitude.to_double() << " phi: " << ophi.to_double() << " kBinsInPi: " << pi_bins_fixed_t(kBinsInPi).to_double() << "\n"
                                            << "Et: " << ret_etmiss.Et.to_double() << " phi (int): " << ret_etmiss.Phi.to_int() << "\n";
   }

--- a/L1Trigger/L1TTrackMatch/src/Cordic.cc
+++ b/L1Trigger/L1TTrackMatch/src/Cordic.cc
@@ -73,8 +73,10 @@ void Cordic::cordic_subfunc(T &x, T &y, T &z) const {
 EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
   EtMiss ret_etmiss;
 
-  edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====toPolar input=====\n"
-                                         << "x: " << x << " y: " << y << "\n";
+  if (debug) {
+    edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====toPolar input=====\n"
+                                           << "x: " << x << " y: " << y;
+  }
 
   // Some needed constants
   const ap_fixed<l1tmetemu::Et_t::width + 1, 3> pi = M_PI;  // pi
@@ -124,6 +126,11 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
     absx = x;
   }
 
+  if (debug) {
+    edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====Abs input=====\n"
+                                           << "abs(x): " << absx.to_double() << " abs(y): " << absy.to_double();
+  }
+
   // Normalization (operate on a unit circle)
   ap_fixed<Et_t::width + 1, 2, Et_t::qmode, Et_t::omode> absx_sft, absy_sft;
   for (int i = 0; i < Et_t::width + 1; i++) {
@@ -131,7 +138,12 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
     absy_sft[i] = absy[i];
   }
 
-  // Setup the CORDIC outputs
+  if (debug) {
+    edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====Normalized input=====\n"
+                                           << "norm(abs(x)): " << absx_sft.to_double() << " norm(abs(y)): " << absy_sft.to_double();
+  }
+
+  // Setup the CORDIC inputs/outputs
   ap_fixed<Et_t::width + 7, 3, Et_t::qmode, Et_t::omode> cx, cy, cphi;
   if (absy > absx) {
     cx = absy_sft;
@@ -139,9 +151,14 @@ EtMiss Cordic::toPolar(Et_t x, Et_t y) const {
     cphi = 0;
   }
   else {
-    x = absx_sft;
-    y = absy_sft;
+    cx = absx_sft;
+    cy = absy_sft;
     cphi = 0;
+  }
+
+  if (debug) {
+    edm::LogVerbatim("L1TkEtMissEmulator") << "\n=====CORDIC function arguments=====\n"
+                                           << "x: " << cx.to_double() << " y: " << cy.to_double() << " phi: " << cphi.to_double();
   }
 
   // Perform the CORDIC (vectoring) function

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -17,9 +17,12 @@ namespace l1tmetemu {
 
   global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift ) {
     global_phi_t PhiMin = 0;
-    global_phi_t PhiMax = 2*M_PI / TTTrack_TrackWord::stepPhi0; 
+    global_phi_t PhiMax = 2*M_PI / TTTrack_TrackWord::stepPhi0;
 
-    int globalPhi = local_phi;
+    // The initial word comes in as a uint; the correct bits, but not automatically using 2s compliment format.
+    global_phi_t globalPhi = local_phi;
+
+    // Once the word is in a larger, signed container, shift it down so that the negative numbers are automatically represented in 2s compliment.
     if (local_phi >= (1 << (TTTrack_TrackWord::TrackBitWidths::kPhiSize - 1)))
       globalPhi -= (1 << TTTrack_TrackWord::TrackBitWidths::kPhiSize);
 
@@ -31,7 +34,7 @@ namespace l1tmetemu {
       globalPhi = globalPhi - PhiMax;
     }  
 
-    return (global_phi_t)globalPhi;
+    return globalPhi;
   }
 
   std::vector<global_phi_t> generatePhiSliceLUT(unsigned int N) {

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -15,9 +15,9 @@ namespace l1tmetemu {
     return cosLUT;
   }
 
-  global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift ) {
+  global_phi_t localToGlobalPhi(TTTrack_TrackWord::phi_t local_phi, global_phi_t sector_shift) {
     global_phi_t PhiMin = 0;
-    global_phi_t PhiMax = 2*M_PI / TTTrack_TrackWord::stepPhi0;
+    global_phi_t PhiMax = 2 * M_PI / TTTrack_TrackWord::stepPhi0;
 
     // The initial word comes in as a uint; the correct bits, but not automatically using 2s compliment format.
     global_phi_t globalPhi = local_phi;
@@ -32,7 +32,7 @@ namespace l1tmetemu {
       globalPhi = globalPhi + PhiMax;
     } else if (globalPhi > PhiMax) {
       globalPhi = globalPhi - PhiMax;
-    }  
+    }
 
     return globalPhi;
   }


### PR DESCRIPTION
#### PR description:

With these changes, the results from the emulation and the firmware match. The main change is to match the CORDIC function more closely with the version used in the firmware. This algorithm is adapted from Xilinx's own code and specifically written for firmware environments. That said, I have adapted the version in this PR to be more software friendly. The main point is that all of the same data types and operations used in the firmware are now performed in the emulation. Without this, it would be next to impossible to get 100% agreement. During this work, a lot of debugging information was added, which makes up a large portion of this PR.

#### PR validation:

I have confirmed that for 100 events the resulting MET words from the firmware and the emulation are the same. I've also looked at the simulation values for 10 events. As expected, these don't match the simulation exactly. I would like to see this for more events to know how different the values are.

I've also done `scram b code-checks` and `scram b code-format`.